### PR TITLE
Introducing a sleep after networkup, in order to wait all the contain…

### DIFF
--- a/network/scripts/network.sh
+++ b/network/scripts/network.sh
@@ -221,6 +221,10 @@ function networkUp() {
 		echo "ERROR !!!! Unable to start network"
 		exit 1
 	fi
+
+	# Give time for docker containers to start
+	echo "Waiting for all the containers to start"
+	sleep 15
 }
 
 # Create a channel by running this function


### PR DESCRIPTION
I have detected that sometimes the channel creation fails, because the orderer and peer containers take longer to start, In the byfn version of the Test network there was a sleep command that solves this issue.
I have introduced the same concept in the networkUp method to fix this problem

Thanks for the starter sample, it is pretty handfull.